### PR TITLE
Security hardening: cookies, input validation, CSP headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .last-branch
 .DS_Store
-data/db/db.sqlite3

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -1,22 +1,38 @@
+import re
 from decimal import Decimal
 from rest_framework import serializers
 from .models import Category, Currency, Expense, ExpenseSplit, Group, GroupType, Settlement, User
 
+_CONTROL_CHAR_RE = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
+
+
+def _strip_text(value):
+    return value.strip() if isinstance(value, str) else value
+
 
 class UserSerializer(serializers.ModelSerializer):
+    display_name = serializers.CharField(max_length=100, required=False, allow_blank=True)
+
     class Meta:
         model = User
         fields = ['id', 'username', 'display_name', 'avatar', 'is_staff']
         read_only_fields = ['id', 'username', 'avatar', 'is_staff']
 
+    def validate_display_name(self, value):
+        return _strip_text(value)
+
 
 class AdminUserSerializer(serializers.ModelSerializer):
     password = serializers.CharField(write_only=True, required=False)
+    display_name = serializers.CharField(max_length=100, required=False, allow_blank=True)
 
     class Meta:
         model = User
         fields = ['id', 'username', 'display_name', 'is_active', 'is_staff', 'password']
         read_only_fields = ['id']
+
+    def validate_display_name(self, value):
+        return _strip_text(value)
 
     def create(self, validated_data):
         password = validated_data.pop('password', None)
@@ -37,24 +53,32 @@ class AdminUserSerializer(serializers.ModelSerializer):
 
 
 class CategorySerializer(serializers.ModelSerializer):
+    name = serializers.CharField(max_length=50)
+
     class Meta:
         model = Category
         fields = ['id', 'name']
 
 
 class GroupTypeSerializer(serializers.ModelSerializer):
+    name = serializers.CharField(max_length=50)
+
     class Meta:
         model = GroupType
         fields = ['id', 'name']
 
 
 class CurrencySerializer(serializers.ModelSerializer):
+    code = serializers.CharField(max_length=3)
+    name = serializers.CharField(max_length=50)
+
     class Meta:
         model = Currency
         fields = ['id', 'name', 'symbol', 'code']
 
 
 class GroupSerializer(serializers.ModelSerializer):
+    name = serializers.CharField(max_length=100)
     member_count = serializers.SerializerMethodField()
     member_ids = serializers.SerializerMethodField()
     group_type_name = serializers.CharField(source='group_type.name', read_only=True)
@@ -69,6 +93,9 @@ class GroupSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ['created_by']
 
+    def validate_name(self, value):
+        return _strip_text(value)
+
     def get_member_count(self, obj):
         return obj.members.count()
 
@@ -78,6 +105,7 @@ class GroupSerializer(serializers.ModelSerializer):
 
 class ExpenseSplitSerializer(serializers.ModelSerializer):
     username = serializers.CharField(source='user.username', read_only=True)
+    amount = serializers.DecimalField(max_digits=12, decimal_places=2)
 
     class Meta:
         model = ExpenseSplit
@@ -85,6 +113,8 @@ class ExpenseSplitSerializer(serializers.ModelSerializer):
 
 
 class ExpenseSerializer(serializers.ModelSerializer):
+    amount = serializers.DecimalField(max_digits=12, decimal_places=2)
+    description = serializers.CharField(max_length=500)
     splits = ExpenseSplitSerializer(many=True, read_only=True)
     split_data = serializers.ListField(
         child=serializers.DictField(), write_only=True, required=False
@@ -100,6 +130,12 @@ class ExpenseSerializer(serializers.ModelSerializer):
             'is_deleted', 'created_at', 'updated_at', 'splits', 'split_data',
         ]
         read_only_fields = ['created_by', 'group', 'is_deleted', 'created_at', 'updated_at']
+
+    def validate_description(self, value):
+        value = _strip_text(value)
+        if _CONTROL_CHAR_RE.search(value):
+            raise serializers.ValidationError('Description contains invalid control characters.')
+        return value
 
     def validate_receipt_image(self, value):
         if value and value.size > 5 * 1024 * 1024:
@@ -153,6 +189,7 @@ class ExpenseSerializer(serializers.ModelSerializer):
 class SettlementSerializer(serializers.ModelSerializer):
     payer_username = serializers.CharField(source='payer.username', read_only=True)
     payee_username = serializers.CharField(source='payee.username', read_only=True)
+    amount = serializers.DecimalField(max_digits=12, decimal_places=2)
 
     class Meta:
         model = Settlement

--- a/backend/memorybank/settings.py
+++ b/backend/memorybank/settings.py
@@ -36,6 +36,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'csp.middleware.CSPMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -103,3 +104,20 @@ REST_FRAMEWORK = {
 }
 
 CSRF_TRUSTED_ORIGINS = os.environ.get('CSRF_TRUSTED_ORIGINS', 'http://localhost').split(',')
+
+# Security headers
+X_FRAME_OPTIONS = 'DENY'
+SECURE_CONTENT_TYPE_NOSNIFF = True
+
+# Content-Security-Policy via django-csp
+CONTENT_SECURITY_POLICY = {
+    "DIRECTIVES": {
+        "default-src": ["'self'"],
+        "script-src": ["'self'"],
+        "style-src": ["'self'", "'unsafe-inline'"],
+        "img-src": ["'self'", "data:"],
+        "font-src": ["'self'"],
+        "connect-src": ["'self'"],
+        "frame-ancestors": ["'none'"],
+    },
+}

--- a/backend/memorybank/settings.py
+++ b/backend/memorybank/settings.py
@@ -21,7 +21,7 @@ SECRET_KEY = _secret_key
 
 DEBUG = os.environ.get('DJANGO_DEBUG', 'false').lower() == 'true'
 
-ALLOWED_HOSTS = os.environ.get('DJANGO_ALLOWED_HOSTS', '*').split(',')
+ALLOWED_HOSTS = os.environ.get('DJANGO_ALLOWED_HOSTS', 'localhost,127.0.0.1').split(',')
 
 INSTALLED_APPS = [
     'django.contrib.admin',
@@ -104,6 +104,21 @@ REST_FRAMEWORK = {
 }
 
 CSRF_TRUSTED_ORIGINS = os.environ.get('CSRF_TRUSTED_ORIGINS', 'http://localhost').split(',')
+
+# Cookie security
+CSRF_COOKIE_HTTPONLY = True
+CSRF_COOKIE_SAMESITE = 'Strict'
+SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SAMESITE = 'Lax'
+
+# HTTPS / SSL settings — gated behind DJANGO_SECURE_SSL env var
+_secure_ssl = os.environ.get('DJANGO_SECURE_SSL', 'false').lower() == 'true'
+CSRF_COOKIE_SECURE = _secure_ssl
+SESSION_COOKIE_SECURE = _secure_ssl
+SECURE_SSL_REDIRECT = _secure_ssl
+SECURE_HSTS_SECONDS = 31536000 if _secure_ssl else 0
+SECURE_HSTS_INCLUDE_SUBDOMAINS = _secure_ssl
+SECURE_HSTS_PRELOAD = _secure_ssl
 
 # Security headers
 X_FRAME_OPTIONS = 'DENY'

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ Django>=5.0,<7.0
 djangorestframework>=3.14
 Pillow>=10.0
 gunicorn>=21.0
+django-csp>=4.0

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -8,6 +8,7 @@ services:
       - DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY:-change-me-to-a-real-secret-key}
       - DJANGO_DEBUG=false
       - DJANGO_ALLOWED_HOSTS=*
+      - DJANGO_SECURE_SSL=${DJANGO_SECURE_SSL:-false}
       - SQLITE_PATH=${SQLITE_PATH:-/data/db/db.sqlite3}
       - MEDIA_ROOT=${MEDIA_ROOT:-/data/media}
       - CSRF_TRUSTED_ORIGINS=${CSRF_TRUSTED_ORIGINS:-http://localhost}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - SQLITE_PATH=/data/db/db.sqlite3
       - MEDIA_ROOT=/data/media
       - DJANGO_ALLOWED_HOSTS=*
+      - DJANGO_SECURE_SSL=false
     volumes:
       - ./data/db:/data/db
       - ./data/media:/data/media

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'">
     <title>Vite App</title>
   </head>
   <body>

--- a/progress.txt
+++ b/progress.txt
@@ -6,6 +6,49 @@ Started: Sun 22 Mar 2026 20:08:44 CET
 - Python venv at `backend/.venv/` — run tests with `.venv/bin/python manage.py test core`
 - Permission classes live in `backend/core/permissions.py`, views import from there
 - Existing `AdminWritePermission` in `views.py` — new permissions go in `permissions.py`
+- Frontend CSP meta tag in `index.html` — update if new asset sources needed
+- django-csp v4 uses `CONTENT_SECURITY_POLICY` dict with `DIRECTIVES` sub-dict, values are lists of strings
+- HTTPS/SSL settings gated behind `DJANGO_SECURE_SSL` env var pattern
+---
+
+## 2026-03-23 - #7 Harden Django cookie & HTTPS security settings
+- Added cookie security (CSRF_COOKIE_HTTPONLY, SAMESITE, SESSION_COOKIE_HTTPONLY, SAMESITE)
+- Added HTTPS settings gated behind `DJANGO_SECURE_SSL` env var
+- Changed ALLOWED_HOSTS default from `*` to `localhost,127.0.0.1`
+- Added DJANGO_SECURE_SSL to docker-compose.yml and docker-compose.ghcr.yml
+- Files changed: `backend/memorybank/settings.py`, `docker-compose.yml`, `docker-compose.ghcr.yml`
+- **Learnings for future iterations:**
+  - Always gate SSL/HTTPS settings behind env var so local dev and tests work without TLS
+  - 71 tests pass
+---
+
+## 2026-03-23 - #8 Add input length & content validation to serializers
+- Added explicit `max_length` to all text serializer fields
+- Added explicit `max_digits=12, decimal_places=2` to all DecimalFields
+- Added whitespace stripping via `validate_<field>` methods
+- Added control character rejection for expense description
+- Files changed: `backend/core/serializers.py`
+- **Learnings for future iterations:**
+  - DRF ModelSerializer inherits model constraints but explicit serializer-level fields override them
+  - 71 tests pass
+---
+
+## 2026-03-23 - #9 Add Content-Security-Policy and security headers via Django
+- Added `django-csp>=4.0` to requirements.txt, `csp.middleware.CSPMiddleware` to MIDDLEWARE
+- Configured CONTENT_SECURITY_POLICY with all directives
+- Set explicit X_FRAME_OPTIONS='DENY' and SECURE_CONTENT_TYPE_NOSNIFF=True
+- Files changed: `backend/requirements.txt`, `backend/memorybank/settings.py`
+- **Learnings for future iterations:**
+  - django-csp v4 uses dict-based config, not the old `CSP_*` settings
+  - 71 tests pass
+---
+
+## 2026-03-23 - #10 Add CSP meta tag to frontend index.html as fallback
+- Added `<meta http-equiv="Content-Security-Policy">` to `frontend/index.html` with directives: default-src 'self', script-src 'self', style-src 'self' 'unsafe-inline', img-src 'self' data:, font-src 'self', connect-src 'self', frame-ancestors 'none'
+- Files changed: `frontend/index.html`
+- **Learnings for future iterations:**
+  - Single-line change, no build/typecheck impact
+  - 71 backend tests pass on this branch
 ---
 
 ## 2026-03-22 - US-009


### PR DESCRIPTION
## Summary
- **#7** Harden Django cookie & HTTPS security settings (secure cookies, HSTS, SSL redirect)
- **#8** Add input length & content validation to serializers (prevent oversized/malicious input)
- **#9** Add Content-Security-Policy and security headers via Django middleware
- **#10** Add CSP meta tag to frontend `index.html` as fallback
- Housekeeping: update `.gitignore`, add `progress.txt` tracking

## Test plan
- [ ] Verify cookies are set with `Secure`, `HttpOnly`, `SameSite` flags
- [ ] Test input validation rejects oversized fields and invalid content
- [ ] Confirm CSP and security headers are present in HTTP responses
- [ ] Check frontend CSP meta tag is rendered in `index.html`
- [ ] Run `python manage.py test core` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)